### PR TITLE
docs: Update security mailing list address

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,6 @@
 
 The Fluid community has a closed-membership security working group who are available to respond to possible security issues, consisting of a small group of committers to Fluid-related projects.
 
-Any suspected security vulnerabilities can be reported privately by email to [security@fluidproject.org](mailto:security@fluidproject.org). These messages will be forwarded to members of the security working group, who are responsible for working with contributors with relevant expertise and the reporter to address the issue in a timely manner.
-
-Once an issue has been fixed and appropriate patches applied, public announcements will be made at an appropriate time to the [security-announce@fluidproject.org](http://fluidproject.org/mailman/listinfo/security-announce) mailing list. For less severe security concerns, patches will be committed to the source code repository with nondescript log messages.
+Any suspected security vulnerabilities can be reported privately by email to [security@lists.idrc.ocad.ca](security@lists.idrc.ocad.ca). These messages will be forwarded to members of the security working group, who are responsible for working with contributors with relevant expertise and the reporter to address the issue in a timely manner.
 
 For more details see the [Security](https://wiki.fluidproject.org/display/fluid/Security) wiki page.


### PR DESCRIPTION
Updates the Security documentation, in particular the e-mail address, based on changes to the [Security](https://wiki.fluidproject.org/display/fluid/Security) wiki page.