### PR TITLE
docs: Update support doc to point at Matrix

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,7 +1,7 @@
 ## Support
 
 If you've encountered an issue, please consider filing an issue. 
-You may also reach out to us on [IRC](https://wiki.fluidproject.org/display/fluid/IRC+Channel) or the [fluid-work mailing list](https://lists.idrc.ocad.ca/mailman/listinfo/fluid-work).
+You may also reach out to us on [Matrix](https://wiki.fluidproject.org/display/fluid/Matrix+Channel) or the [fluid-work mailing list](https://lists.idrc.ocad.ca/mailman/listinfo/fluid-work).
 
 ## Participating
 


### PR DESCRIPTION
The Fluid community has moved from IRC to Matrix for chat discussions.

resolves #4